### PR TITLE
Build/compiler fix for incompatible pointer types gcc version 14.1.1 …

### DIFF
--- a/src/ossimPlanet/crypt.h
+++ b/src/ossimPlanet/crypt.h
@@ -27,12 +27,15 @@
    Encryption is not supported.
 */
 
+#include <stdint.h>
+
 #define CRC32(c, b) ((*(pcrc_32_tab+(((int)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))
 
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
+// static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
+static int decrypt_byte(unsigned long* pkeys, const uint32_t* pcrc_32_tab)   
 {
     unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                      * unpredictable manner on 16-bit systems; not a problem
@@ -45,7 +48,8 @@ static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
 /***********************************************************************
  * Update the encryption keys with the next byte of plain text
  */
-static int update_keys(unsigned long* pkeys,const unsigned long* pcrc_32_tab,int c)
+// static int update_keys(unsigned long* pkeys,const unsigned long* pcrc_32_tab,int c)
+static int update_keys(unsigned long* pkeys,const uint32_t* pcrc_32_tab,int c)   
 {
     (*(pkeys+0)) = CRC32((*(pkeys+0)), c);
     (*(pkeys+1)) += (*(pkeys+0)) & 0xff;
@@ -62,7 +66,8 @@ static int update_keys(unsigned long* pkeys,const unsigned long* pcrc_32_tab,int
  * Initialize the encryption keys and the random header according to
  * the given password.
  */
-static void init_keys(const char* passwd,unsigned long* pkeys,const unsigned long* pcrc_32_tab)
+// static void init_keys(const char* passwd,unsigned long* pkeys,const unsigned long* pcrc_32_tab)
+static void init_keys(const char* passwd,unsigned long* pkeys,const uint32_t* pcrc_32_tab)   
 {
     *(pkeys+0) = 305419896L;
     *(pkeys+1) = 591751049L;
@@ -92,7 +97,8 @@ static int crypthead(passwd, buf, bufSize, pkeys, pcrc_32_tab, crcForCrypting)
     unsigned char *buf;         /* where to write header */
     int bufSize;
     unsigned long* pkeys;
-    const unsigned long* pcrc_32_tab;
+    // const unsigned long* pcrc_32_tab;
+    const uint32_t* pcrc_32_tab;
     unsigned long crcForCrypting;
 {
     int n;                       /* index in random header */

--- a/src/ossimPlanet/unzip.c
+++ b/src/ossimPlanet/unzip.c
@@ -35,6 +35,7 @@ woven in by Terry Thorsen 1/2003.
  */
 
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -147,7 +148,8 @@ typedef struct
     int encrypted;
 #    ifndef NOUNCRYPT
     unsigned long keys[3];     /* keys defining the pseudo-random sequence */
-    const unsigned long* pcrc_32_tab;
+    // const unsigned long* pcrc_32_tab;
+    const uint32_t* pcrc_32_tab;
 #    endif
 } unz_s;
 

--- a/src/ossimPlanet/zip.c
+++ b/src/ossimPlanet/zip.c
@@ -130,7 +130,8 @@ typedef struct
     int  encrypt;
 #ifndef NOCRYPT
     unsigned long keys[3];     /* keys defining the pseudo-random sequence */
-    const unsigned long* pcrc_32_tab;
+    // const unsigned long* pcrc_32_tab;
+    const uint32_t* pcrc_32_tab;   
     int crypt_header_size;
 #endif
 } curfile_info;


### PR DESCRIPTION
Build/compiler fix for incompatible pointer types gcc version 14.1.1 (Fedora 40).